### PR TITLE
Fix a bug in MaskInverse.Filter().

### DIFF
--- a/copy_test.go
+++ b/copy_test.go
@@ -877,16 +877,21 @@ func TestStructToStruct_MaskWithInverseMask(t *testing.T) {
 		B: "B",
 		C: "C",
 	}
-	dst := &B{}
-	mask := fieldmask_utils.Mask{"B": nil, "A": &fieldmask_utils.MaskInverse{"Bar": nil}}
-	err := fieldmask_utils.StructToStruct(mask, src, dst)
-	assert.NoError(t, err)
-	assert.Equal(t, &B{
-		A: A{
-			Foo: src.A.Foo,
-		},
-		B: "B",
-	}, dst)
+	for _, mask := range []fieldmask_utils.FieldFilter{
+		fieldmask_utils.Mask{"B": nil, "A": &fieldmask_utils.MaskInverse{"Bar": nil}},
+		fieldmask_utils.Mask{"B": fieldmask_utils.Mask{}, "A": &fieldmask_utils.MaskInverse{"Bar": fieldmask_utils.Mask{}}},
+	}{
+		dst := &B{}
+		err := fieldmask_utils.StructToStruct(mask, src, dst)
+		assert.NoError(t, err)
+		assert.Equal(t, &B{
+			A: A{
+				Foo: src.A.Foo,
+			},
+			B: "B",
+		}, dst)
+	}
+
 }
 
 func TestStructToStruct_InverseMaskWithMask(t *testing.T) {
@@ -908,16 +913,21 @@ func TestStructToStruct_InverseMaskWithMask(t *testing.T) {
 		B: "B",
 		C: "C",
 	}
-	dst := &B{}
-	mask := fieldmask_utils.MaskInverse{"B": nil, "A": &fieldmask_utils.Mask{"Bar": nil}}
-	err := fieldmask_utils.StructToStruct(mask, src, dst)
-	assert.NoError(t, err)
-	assert.Equal(t, &B{
-		A: A{
-			Bar: src.A.Bar,
-		},
-		C: "C",
-	}, dst)
+	for _, mask := range []fieldmask_utils.FieldFilter{
+		fieldmask_utils.MaskInverse{"B": fieldmask_utils.Mask{}, "A": &fieldmask_utils.Mask{"Bar": fieldmask_utils.Mask{}}},
+		fieldmask_utils.MaskInverse{"B": nil, "A": &fieldmask_utils.Mask{"Bar": nil}},
+	} {
+		dst := &B{}
+		err := fieldmask_utils.StructToStruct(mask, src, dst)
+		assert.NoError(t, err)
+		assert.Equal(t, &B{
+			A: A{
+				Bar: src.A.Bar,
+			},
+			C: "C",
+		}, dst)
+	}
+
 }
 
 func TestStructToMap_NestedStruct_EmptyDst(t *testing.T) {

--- a/mask.go
+++ b/mask.go
@@ -38,6 +38,7 @@ func (m Mask) Filter(fieldName string) (FieldFilter, bool) {
 	return subFilter, ok
 }
 
+// IsEmpty returns true of the mask is empty.
 func (m Mask) IsEmpty() bool {
 	return len(m) == 0
 }
@@ -68,7 +69,7 @@ func (m Mask) String() string {
 }
 
 // MaskInverse is an inversed version of a Mask (will copy all the fields except those mentioned in the mask).
-type MaskInverse Mask
+type MaskInverse map[string]FieldFilter
 
 // Filter returns true for those fieldNames that do NOT exist in the underlying map.
 // Field names that start with "XXX_" are ignored as unexported.
@@ -77,9 +78,13 @@ func (m MaskInverse) Filter(fieldName string) (FieldFilter, bool) {
 	if !ok {
 		return MaskInverse{}, !strings.HasPrefix(fieldName, "XXX_")
 	}
-	return subFilter, subFilter != nil
+	if subFilter == nil {
+		return nil, false
+	}
+	return subFilter, !subFilter.IsEmpty()
 }
 
+// IsEmpty returns true if the mask is empty.
 func (m MaskInverse) IsEmpty() bool {
 	return len(m) == 0
 }


### PR DESCRIPTION
Make the filtering logic consistent for `nil` and empty subMasks in MaskInverse.Filter()