### PR TITLE
fix bug fix bug: panic: reflect.Value.Interface: cannot return value obtained from unexported field or method in 'StructToMap'

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -237,6 +237,10 @@ func StructToMap(filter FieldFilter, src interface{}, dst map[string]interface{}
 	srcType := srcVal.Type()
 	for i := 0; i < srcVal.NumField(); i++ {
 		fieldName := srcType.Field(i).Name
+		// fix bug: panic: reflect.Value.Interface: cannot return value obtained from unexported field or method
+		if !checkAccess(fieldName) {
+			continue
+		}
 		subFilter, ok := filter.Filter(fieldName)
 		if !ok {
 			// Skip this field.
@@ -340,4 +344,12 @@ func indirect(v reflect.Value) reflect.Value {
 		v = v.Elem()
 	}
 	return v
+}
+
+func checkAccess(fieldName string) bool {
+	// unexported field begins with lower case in golang
+	if strings.ToUpper(fieldName[:1]) == fieldName[:1] {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
case
src struct: 
`
type UnexportStruct struct {
		Field1 *timestamp.Timestamp // github.com/golang/protobuf/ptypes/timestamp
		Field2 int
}
`
mask: []string{"Field1", "Field2"}
StructToMap will get panic when deep copy 'state' (unexported field) in timestamp 