### PR TITLE
add support of dst structs with pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ fieldmask_utils.StructToStruct(mask, request.User, userDst)
 
 2.  Masks inside a protobuf `Map` are not supported.
 3.  When copying from a struct to struct the destination struct must have the same fields (or a subset)
-    as the source struct. Pointers must also be coherent: if a field is a pointer in the source struct, then
-    it also must be a pointer (not a value field) in the destination struct.
+    as the source struct. Either of source or destination fields can be a pointer as long as it is a pointer to
+    the type of the corresponding field.
 4. `oneof` fields are represented differently in `fieldmaskpb.FieldMask` compared to `fieldmask_util.Mask`. In 
     [FieldMask](https://pkg.go.dev/google.golang.org/protobuf/types/known/fieldmaskpb#:~:text=%23%20Field%20Masks%20and%20Oneof%20Fields)
     the fields are represented using their property name, in this library they are prefixed with the `oneof` name

--- a/copy_test.go
+++ b/copy_test.go
@@ -47,6 +47,104 @@ func TestStructToStruct_PtrToInt(t *testing.T) {
 	}, dst)
 }
 
+func TestStructToStruct_StructToPointer(t *testing.T) {
+	v15 := 15
+	v42 := 42
+
+	type N struct {
+		Field1 int
+	}
+	type S struct {
+		Field1 N
+		Field2 int
+	}
+	src := &S{
+		Field1: N{
+			Field1: v15,
+		},
+		Field2: v42,
+	}
+	type SN struct {
+		Field1 *int
+	}
+	type D struct {
+		Field1 *SN
+		Field2 *int
+	}
+	dst := new(D)
+
+	mask := fieldmask_utils.MaskFromString("Field1,Field2")
+	err := fieldmask_utils.StructToStruct(mask, src, dst)
+	require.NoError(t, err)
+	assert.Equal(t, &D{
+		Field1: &SN{
+			Field1: &v15,
+		},
+		Field2: &v42,
+	}, dst)
+}
+
+func TestStructToStruct_IntToPointer(t *testing.T) {
+	v := 42
+
+	type S struct {
+		Field2 int
+	}
+	src := &S{
+		Field2: v,
+	}
+	type D struct {
+		Field2 *int
+	}
+	dst := new(D)
+
+	mask := fieldmask_utils.MaskFromString("Field2")
+	err := fieldmask_utils.StructToStruct(mask, src, dst)
+	require.NoError(t, err)
+	assert.Equal(t, &D{
+		Field2: &v,
+	}, dst)
+}
+
+func TestStructToStruct_PointerToInt(t *testing.T) {
+	v := 42
+
+	type S struct {
+		Field2 *int
+	}
+	src := &S{
+		Field2: &v,
+	}
+	type D struct {
+		Field2 int
+	}
+	dst := new(D)
+
+	mask := fieldmask_utils.MaskFromString("Field2")
+	err := fieldmask_utils.StructToStruct(mask, src, dst)
+	require.NoError(t, err)
+	assert.Equal(t, &D{
+		Field2: 42,
+	}, dst)
+}
+
+func TestStructToStruct_Incompatible(t *testing.T) {
+	type S struct {
+		Field2 int
+	}
+	src := &S{
+		Field2: 42,
+	}
+	type D struct {
+		Field2 string
+	}
+	dst := new(D)
+
+	mask := fieldmask_utils.MaskFromString("Field2")
+	err := fieldmask_utils.StructToStruct(mask, src, dst)
+	require.EqualError(t, err, "src kind int differs from dst kind string")
+}
+
 func TestStructToStruct_PtrToStruct_EmptyDst(t *testing.T) {
 	type A struct {
 		Field1 string


### PR DESCRIPTION
Hi!

It would be great to support copying to structs that use pointers to the same types, e.g.:

```golang
type ChangedUser {
    Name *string
    Age *int
}

var request UpdateUserRequest
dst := &ChangedUser{}// a struct to copy to
mask, err := fieldmask_utils.MaskFromPaths(request.FieldMask.Paths, generator.CamelCase)
// handle err...
fieldmask_utils.StructToStruct(mask, request.User, dst)
```

Thanks!