### PR TITLE
feature: src tag

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -2,11 +2,12 @@
 package fieldmask_utils
 
 import (
+	"reflect"
+	"strings"
+
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
-	"reflect"
-	"strings"
 )
 
 // StructToStruct copies `src` struct to `dst` struct using the given FieldFilter.
@@ -71,16 +72,16 @@ func structToStruct(filter FieldFilter, src, dst *reflect.Value, userOptions *op
 
 		for i := 0; i < src.NumField(); i++ {
 			srcType := src.Type()
-			fieldName := srcType.Field(i).Name
+			srcName := dstKey(userOptions.SrcTag, srcType.Field(i))
 			dstName := dstKey(userOptions.DstTag, srcType.Field(i))
 
-			subFilter, ok := filter.Filter(fieldName)
+			subFilter, ok := filter.Filter(srcName)
 			if !ok {
 				// Skip this field.
 				continue
 			}
 
-			srcField := src.FieldByName(fieldName)
+			srcField := src.Field(i)
 			if !srcField.CanInterface() {
 				continue
 			}
@@ -236,6 +237,7 @@ func structToStruct(filter FieldFilter, src, dst *reflect.Value, userOptions *op
 // options are used in StructToStruct and StructToMap functions to modify the copying behavior.
 type options struct {
 	DstTag string
+	SrcTag string // copy according to src tag, i.g. json
 
 	// CopyListSize can control the number of elements copied from src depending on src's Value
 	CopyListSize func(src *reflect.Value) int
@@ -264,6 +266,13 @@ type Option func(*options)
 func WithTag(s string) Option {
 	return func(o *options) {
 		o.DstTag = s
+	}
+}
+
+// WithSrcTag set SrcTag of option, you can copy field according to field's tag of src object.
+func WithSrcTag(s string) Option {
+	return func(o *options) {
+		o.SrcTag = s
 	}
 }
 
@@ -321,18 +330,18 @@ func structToMap(filter FieldFilter, src, dst reflect.Value, userOptions *option
 		}
 		srcType := src.Type()
 		for i := 0; i < src.NumField(); i++ {
-			fieldName := srcType.Field(i).Name
+			srcName  := dstKey(userOptions.SrcTag, srcType.Field(i))
 			if !isExported(srcType.Field(i)) {
 				// Unexported fields can not be copied.
 				continue
 			}
 
-			subFilter, ok := filter.Filter(fieldName)
+			subFilter, ok := filter.Filter(srcName)
 			if !ok {
 				// Skip this field.
 				continue
 			}
-			srcField := indirect(src.FieldByName(fieldName))
+			srcField := indirect(src.Field(i))
 			dstName := dstKey(userOptions.DstTag, srcType.Field(i))
 			mapValue := indirect(dst.MapIndex(reflect.ValueOf(dstName)))
 			if !mapValue.IsValid() {
@@ -345,7 +354,7 @@ func structToMap(filter FieldFilter, src, dst reflect.Value, userOptions *option
 				}
 			}
 			if userOptions.MapVisitor != nil {
-				result := userOptions.MapVisitor(filter, src, mapValue, fieldName, dstName, srcField)
+				result := userOptions.MapVisitor(filter, src, mapValue, srcName, dstName, srcField)
 				if result.UpdatedDst != nil {
 					mapValue = *result.UpdatedDst
 

--- a/copy_test.go
+++ b/copy_test.go
@@ -3,11 +3,12 @@ package fieldmask_utils_test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	fieldmask_utils "github.com/mennanov/fieldmask-utils"
 )
@@ -1213,6 +1214,26 @@ func TestStructToMap_NestedStruct_EmptyDst_OptionDst(t *testing.T) {
 			"some_field": src.A.Field2,
 		},
 	}, dst)
+
+	// with src tag
+	dst = make(map[string]interface{})
+	err = fieldmask_utils.StructToMap(mask, src, dst, opts, fieldmask_utils.WithSrcTag("db"))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"Field1": src.Field1,
+	}, dst)
+
+	mask = fieldmask_utils.MaskFromString("Field1,another_name{some_field}")
+	dst = make(map[string]interface{})
+	err = fieldmask_utils.StructToMap(mask, src, dst, opts, fieldmask_utils.WithSrcTag("db"))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"Field1": src.Field1,
+		"another_name": map[string]interface{}{
+			"some_field": src.A.Field2,
+		},
+	}, dst)
+
 }
 
 func TestStructToMap_NestedStruct_NonEmptyDst(t *testing.T) {
@@ -1992,6 +2013,15 @@ func TestStructToStruct_WithMultiTagComma(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{
 		"field": 1,
+	}, dst)
+
+	// src tag
+	mask = fieldmask_utils.MaskFromString("field")
+	dst = make(map[string]interface{})
+	err = fieldmask_utils.StructToMap(mask, src, dst, fieldmask_utils.WithSrcTag("json"))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"Field": 1,
 	}, dst)
 }
 


### PR DESCRIPTION
some times, `mask` may using json field. this feature we can copy according to field's tag of src object.
useage：
```go
type A struct {
	Field1 string
	Field2 int `db:"some_field"`
}
type B struct {
	Field1 string `struct:"a_name"`
	A      A      `db:"another_name"`
}
src := &B{
	Field1: "B Field1",
	A: A{
		Field1: "A Field 1",
		Field2: 1,
	},
}
mask, _ = fieldmask_utils.MaskFromPaths([]string{"Field1","another_name.some_field"}, func(s string) string {return s})
dst := make(map[string]interface{})
err = fieldmask_utils.StructToMap(mask, src, dst, fieldmask_utils.WithSrcTag("db"))
fmt.Println(err)
// dst is map[string]interface{}{
// 	"Field1": src.Field1,
// 	"another_name": map[string]interface{}{
// 		"some_field": src.A.Field2,
// 	},
// }
fmt.Println(dst)
```