### PR TITLE
If any messages do not have a subfilter then don't introspect them.

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -113,6 +113,12 @@ func structToStruct(filter FieldFilter, src, dst *reflect.Value, userOptions *op
 				return errors.Errorf("dst type is %s, expected: %s ", dst.Type(), "*any.Any")
 			}
 
+			// If subfilter is empty then copy the entire any without any unmarshalling.
+			if filter.IsEmpty() {
+				dst.Set(*src)
+				break
+			}
+
 			srcProto, err := srcAny.UnmarshalNew()
 			if err != nil {
 				return errors.WithStack(err)
@@ -334,7 +340,7 @@ func structToMap(filter FieldFilter, src, dst reflect.Value, userOptions *option
 		}
 		srcType := src.Type()
 		for i := 0; i < src.NumField(); i++ {
-			srcName  := fieldName(userOptions.SrcTag, srcType.Field(i))
+			srcName := fieldName(userOptions.SrcTag, srcType.Field(i))
 			if !isExported(srcType.Field(i)) {
 				// Unexported fields can not be copied.
 				continue

--- a/copy_proto_test.go
+++ b/copy_proto_test.go
@@ -277,6 +277,27 @@ func TestStructToStruct_NonProtoFail(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestStructToStruct_UnknownAny(t *testing.T) {
+	userSrc := &testproto.User{
+		Details: []*anypb.Any{
+			{
+				TypeUrl: "example.com/example/UnknownType",
+				Value:   []byte("unknown"),
+			},
+		},
+	}
+	userDst := &testproto.User{}
+
+	mask := fieldmask_utils.MaskFromString("Details")
+
+	err := fieldmask_utils.StructToStruct(mask, userSrc, userDst)
+	assert.NoError(t, err)
+	assert.Equal(t, userSrc.Details, userDst.Details)
+
+	mask = fieldmask_utils.MaskFromString("Details{Id}")
+	err = fieldmask_utils.StructToStruct(mask, userSrc, userDst)
+	assert.Equal(t, "proto: not found", err.Error())
+}
 func TestStructToMap_Success(t *testing.T) {
 	userDst := make(map[string]interface{})
 	mask := fieldmask_utils.MaskFromString(


### PR DESCRIPTION
Allows for unknown anys to be mapped