### PR TITLE
no error on empty subfilter

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -88,7 +88,13 @@ func structToStruct(filter FieldFilter, src, dst *reflect.Value, userOptions *op
 
 			dstField := dst.FieldByName(dstName)
 			if !dstField.CanSet() {
-				return errors.Errorf("Can't set a value on a destination field %s", dstName)
+				if subFilter.IsEmpty() {
+					// skip field from source not found in destination given above subfilter is ok and empty.
+					continue
+
+				} else {
+					return errors.Errorf("Can't set a value on a destination field %s", dstName)
+				}
 			}
 
 			if err := structToStruct(subFilter, &srcField, &dstField, userOptions); err != nil {

--- a/copy_proto_test.go
+++ b/copy_proto_test.go
@@ -274,7 +274,9 @@ func TestStructToStruct_NonProtoFail(t *testing.T) {
 	userDst := &testproto.User{}
 	mask := fieldmask_utils.MaskFromString("")
 	err := fieldmask_utils.StructToStruct(mask, userSrc, userDst)
-	assert.NotNil(t, err)
+	assert.NoError(t, err)
+	assert.Equal(t, userSrc.Id, userDst.Id)
+	assert.Equal(t, userSrc.Deactivated, userDst.Deactivated)
 }
 
 func TestStructToStruct_UnknownAnyInSrcNoSubfieldMask(t *testing.T) {

--- a/copy_test.go
+++ b/copy_test.go
@@ -1010,7 +1010,10 @@ func TestStructToStruct_SameInterfacesNonPtr_NonEmptyDst(t *testing.T) {
 
 	mask := fieldmask_utils.MaskFromString("Stringer")
 	err := fieldmask_utils.StructToStruct(mask, src, dst)
-	assert.Error(t, err)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Jessica", src.Stringer.String())
+	assert.Equal(t, "Adam", dst.Stringer.String())
 }
 
 func TestStructToStruct_NonPtrDst(t *testing.T) {


### PR DESCRIPTION
- Continue without erroring if a field in source doesn't exist in destination when the mask filter is empty.