### PR TITLE
fix: panic on different nil slices

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -199,7 +199,7 @@ func structToStruct(filter FieldFilter, src, dst *reflect.Value, userOptions *op
 	case reflect.Slice:
 		if src.IsNil() {
 			// If the source slice is nil the dst slice is set to nil too.
-			dst.Set(*src)
+			dst.Set(reflect.Zero(dst.Type()))
 			break
 		}
 


### PR DESCRIPTION
This fixes a panic which occurs when assigning from a nil slice into another slice of a different kind.
It adds a test for this issue in WithConverterHook test.
It also adds a testcase to use multiple converters.