### PR TITLE
allow StructToStruct to copy struct fields to primitives using converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,51 @@ func main() {
 }
 ```
 
+Conversion example from `*timestamppb.Timestamp` to `time.Time`:
+
+```go
+type A struct {
+    Field1 *timestamppb.Timestamp
+}
+type B struct {
+    Field1 time.Time
+}
+
+func main() {
+	src := &A{
+		Field1: &timestamppb.Timestamp{
+			Seconds: 1780396738,
+			Nanos:   42,
+		},
+	}
+	dst := &B{}
+	mask := fieldmask_utils.MaskFromString("Field1")
+
+    err = fieldmask_utils.StructToStruct(mask, src, dst,
+		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (interface{}, error) {
+			data := src.Interface()
+
+            // only care for this conversion
+			if src.Kind() != reflect.TypeFor[*timestamppb.Timestamp]().Kind() ||
+				dst.Kind() != reflect.TypeFor[time.Time]().Kind() {
+				return data, nil
+			}
+
+            // cast it
+			raw, ok := data.(*timestamppb.Timestamp)
+			if !ok {
+				return data, nil
+			}
+
+            // convert it
+			return raw.AsTime(), nil
+		}))
+
+	fmt.Println("src:", src)
+	fmt.Println("dst:", dst)
+}
+```
+
 ### Limitations
 
 1.  Larger scope field masks have no effect and are not considered invalid:
@@ -178,6 +223,9 @@ func main() {
 3.  When copying from a struct to struct the destination struct must have the same fields (or a subset)
     as the source struct. Either of source or destination fields can be a pointer as long as it is a pointer to
     the type of the corresponding field.
+    You can overcome this limitation by providing converter hooks.
+    A common use-case would be to copy fields of different types (including struct to primitive).
+    See the example [Converter hooks](#converter-hooks).
 4. `oneof` fields are represented differently in `fieldmaskpb.FieldMask` compared to `fieldmask_util.Mask`. In
     [FieldMask](https://pkg.go.dev/google.golang.org/protobuf/types/known/fieldmaskpb#:~:text=%23%20Field%20Masks%20and%20Oneof%20Fields)
     the fields are represented using their property name, in this library they are prefixed with the `oneof` name

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Features:
 
 * Copy from any Go struct to any compatible Go struct with a field mask applied
-* Copy from any Go struct to a `map[string]interface{}` with a field mask applied
+* Copy from any Go struct to a `map[string]any` with a field mask applied
 * Extensible masks (e.g. inverse mask: copy all except those mentioned, etc.)
 * Supports [Protobuf Any](https://developers.google.com/protocol-buffers/docs/proto3#any) message types.
 
@@ -16,19 +16,16 @@ If you're looking for a simple FieldMask library to work with protobuf messages 
 
 Copy from a protobuf message to a protobuf message:
 
-```proto
-// testproto/test.proto
-
-message UpdateUserRequest {
-    User user = 1;
-    google.protobuf.FieldMask field_mask = 2;
-}
-```
-
 ```go
 package main
 
-import fieldmask_utils "github.com/mennanov/fieldmask-utils"
+import (
+	"fmt"
+
+	fieldmask_utils "github.com/mennanov/fieldmask-utils"
+	"github.com/mennanov/fieldmask-utils/testproto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
 
 // A function that maps field mask field names to the names used in Go structs.
 // It has to be implemented according to your needs.
@@ -40,44 +37,72 @@ func naming(s string) string {
 	return s
 }
 
-func main () {
-	var request UpdateUserRequest
+// A simple request object for these examples
+var request = &testproto.UpdateUserRequest{
+	User: &testproto.User{
+		Username: "John Doe",
+		Id:       42,
+	},
+	FieldMask: &fieldmaskpb.FieldMask{
+		Paths: []string{"Username"},
+	},
+}
+
+func main() {
 	userDst := &testproto.User{} // a struct to copy to
-	mask, _ := fieldmask_utils.MaskFromPaths(request.FieldMask.Paths, naming)
-	fieldmask_utils.StructToStruct(mask, request.User, userDst)
+	mask, err := fieldmask_utils.MaskFromPaths(request.FieldMask.Paths, naming)
+	if err != nil {
+		panic(err)
+	}
 	// Only the fields mentioned in the field mask will be copied to userDst, other fields are left intact
+	err = fieldmask_utils.StructToStruct(mask, request.User, userDst)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Resulting struct:", userDst)
+	// Resulting struct: username:"John Doe"
 }
 ```
 
-Copy from a protobuf message to a `map[string]interface{}`:
+Copy from a protobuf message to a `map[string]any`:
 
 ```go
-package main
-
-import fieldmask_utils "github.com/mennanov/fieldmask-utils"
+// ...
 
 func main() {
-	var request UpdateUserRequest
-	userDst := make(map[string]interface{}) // a map to copy to
-	mask, _ := fieldmask_utils.MaskFromProtoFieldMask(request.FieldMask, naming)
-	err := fieldmask_utils.StructToMap(mask, request.User, userDst)
+	userDst := make(map[string]any) // a map to copy to
+	mask, err := fieldmask_utils.MaskFromProtoFieldMask(request.FieldMask, naming)
+	if err != nil {
+		panic(err)
+	}
 	// Only the fields mentioned in the field mask will be copied to userDst, other fields are left intact
+	err = fieldmask_utils.StructToMap(mask, request.User, userDst)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Resulting map:", userDst)
+	// Resulting map: map[Username:John Doe]
 }
 ```
 
 Copy with an inverse mask:
 
 ```go
-package main
-
-import fieldmask_utils "github.com/mennanov/fieldmask-utils"
+// ...
 
 func main() {
-	var request UpdateUserRequest
 	userDst := &testproto.User{} // a struct to copy to
 	mask := fieldmask_utils.MaskInverse{"Id": nil, "Friends": fieldmask_utils.MaskInverse{"Username": nil}}
-	fieldmask_utils.StructToStruct(mask, request.User, userDst)
-	// Only the fields that are not mentioned in the field mask will be copied to userDst, other fields are left intact.
+	// Only the fields mentioned in the field mask will be copied to userDst, other fields are left intact
+	err := fieldmask_utils.StructToStruct(mask, request.User, userDst)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Resulting struct:", userDst)
+	// Resulting struct: username:"John Doe"
 }
 ```
 
@@ -94,28 +119,27 @@ there are multiple options for the naming function described above:
       already took care of [copying the code](https://github.com/gojaguar/jaguar/blob/main/strings/pascal_case.go), and also added tests.
 
 ```go
+// ...
+
+import jstrings "github.com/gojaguar/jaguar/strings"
+
 func main() {
-    mask := &fieldmaskpb.FieldMask{Paths: []string{"username"}}
-    mask.Normalize()
-    req := &UpdateUserRequest{
-        User: &User{
-            Id:       1234,
-            Username: "Test",
-        },
-    }
-    if !mask.IsValid(req) {
-        return
-    }
-    protoMask, err := fieldmask_utils.MaskFromProtoFieldMask(mask, strings.PascalCase)
-    if err != nil {
-        return
-    }
-    m := make(map[string]any)
-    err = fieldmask_utils.StructToMap(protoMask, req, m)
+	mask := &fieldmaskpb.FieldMask{Paths: []string{"user.username"}}
+	mask.Normalize()
+	if !mask.IsValid(request) {
+		panic("invalid request")
+	}
+	protoMask, err := fieldmask_utils.MaskFromProtoFieldMask(mask, jstrings.PascalCase)
 	if err != nil {
-		return
-    }
+		panic(err)
+	}
+	m := make(map[string]any)
+	err = fieldmask_utils.StructToMap(protoMask, request, m)
+	if err != nil {
+		panic(err)
+	}
 	fmt.Println("Resulting map:", m)
+	// Resulting map: map[User:map[Username:John Doe]]
 }
 ```
 
@@ -129,6 +153,8 @@ All provided converter functions will be tried in order until src is assignable 
 Below you will find an example of how to convert from string to int64 when applying a mask by specifying such converter:
 
 ```go
+// ...
+
 type A struct {
     Field1 string
 }
@@ -143,34 +169,32 @@ func main() {
 	dst := &B{}
 	mask := fieldmask_utils.MaskFromString("Field1")
 
-    err = fieldmask_utils.StructToStruct(mask, src, dst,
-		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (interface{}, error) {
-			data := src.Interface()
-
-            // only care for this conversion
-			if src.Kind() != reflect.String ||
-				dst.Kind() != reflect.Int64 {
-				return data, nil
+	err := fieldmask_utils.StructToStruct(mask, src, dst,
+		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (any, error) {
+			if src.Type() != reflect.TypeFor[string]() ||
+				dst.Type() != reflect.TypeFor[int64]() {
+				return src.Interface(), nil
 			}
-
-            // cast it
-			raw, ok := data.(string)
-			if !ok {
-				return data, nil
-			}
-
-            // parse it
-			return strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+			return strconv.ParseInt(strings.TrimSpace(src.Interface().(string)), 10, 64)
 		}))
+	if err != nil {
+		panic(err)
+	}
 
 	fmt.Println("src:", src)
 	fmt.Println("dst:", dst)
+	// src: &{   42   }
+	// dst: &{42}
 }
 ```
 
 Conversion example from `*timestamppb.Timestamp` to `time.Time`:
 
 ```go
+// ...
+
+import "google.golang.org/protobuf/types/known/timestamppb"
+
 type A struct {
     Field1 *timestamppb.Timestamp
 }
@@ -188,28 +212,22 @@ func main() {
 	dst := &B{}
 	mask := fieldmask_utils.MaskFromString("Field1")
 
-    err = fieldmask_utils.StructToStruct(mask, src, dst,
-		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (interface{}, error) {
-			data := src.Interface()
-
-            // only care for this conversion
-			if src.Kind() != reflect.TypeFor[*timestamppb.Timestamp]().Kind() ||
-				dst.Kind() != reflect.TypeFor[time.Time]().Kind() {
-				return data, nil
+	err := fieldmask_utils.StructToStruct(mask, src, dst,
+		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (any, error) {
+			if src.Type() != reflect.TypeFor[*timestamppb.Timestamp]() ||
+				dst.Type() != reflect.TypeFor[time.Time]() {
+				return src.Interface(), nil
 			}
-
-            // cast it
-			raw, ok := data.(*timestamppb.Timestamp)
-			if !ok {
-				return data, nil
-			}
-
-            // convert it
-			return raw.AsTime(), nil
+			return src.Interface().(*timestamppb.Timestamp).AsTime(), nil
 		}))
+	if err != nil {
+		panic(err)
+	}
 
 	fmt.Println("src:", src)
 	fmt.Println("dst:", dst)
+	// src: &{seconds:1780396738 nanos:42}
+	// dst: &{2026-06-02 10:38:58.000000042 +0000 UTC}
 }
 ```
 

--- a/copy.go
+++ b/copy.go
@@ -14,14 +14,14 @@ import (
 // Only the fields where FieldFilter returns true will be copied to `dst`.
 // `src` and `dst` must be coherent in terms of the field names, but it is not required for them to be of the same type.
 // Unexported fields are copied only if the corresponding struct filter is empty and `dst` is assignable to `src`.
-func StructToStruct(filter FieldFilter, src, dst interface{}, userOpts ...Option) error {
+func StructToStruct(filter FieldFilter, src, dst any, userOpts ...Option) error {
 	opts := newDefaultOptions()
 	for _, o := range userOpts {
 		o(opts)
 	}
 
 	dstVal := reflect.ValueOf(dst)
-	if dstVal.Kind() != reflect.Ptr {
+	if dstVal.Kind() != reflect.Pointer {
 		return errors.Errorf("dst must be a pointer, %s given", dstVal.Kind())
 	}
 	srcVal := indirect(reflect.ValueOf(src))
@@ -37,11 +37,11 @@ func StructToStruct(filter FieldFilter, src, dst interface{}, userOpts ...Option
 
 func ensureCompatible(src, dst *reflect.Value) error {
 	srcKind := src.Kind()
-	if srcKind == reflect.Ptr {
+	if srcKind == reflect.Pointer {
 		srcKind = src.Type().Elem().Kind()
 	}
 	dstKind := dst.Kind()
-	if dstKind == reflect.Ptr {
+	if dstKind == reflect.Pointer {
 		dstKind = dst.Type().Elem().Kind()
 	}
 	if srcKind != dstKind {
@@ -90,7 +90,7 @@ func structToStruct(filter FieldFilter, src, dst *reflect.Value, userOptions *op
 			return nil
 		}
 
-		if dst.Kind() == reflect.Ptr {
+		if dst.Kind() == reflect.Pointer {
 			if dst.IsNil() {
 				dst.Set(reflect.New(dst.Type().Elem()))
 			}
@@ -124,13 +124,13 @@ func structToStruct(filter FieldFilter, src, dst *reflect.Value, userOptions *op
 			}
 		}
 
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if src.IsNil() {
 			// If src is nil set dst to nil too.
 			dst.Set(reflect.Zero(dst.Type()))
 			break
 		}
-		if dst.Kind() == reflect.Ptr && dst.IsNil() {
+		if dst.Kind() == reflect.Pointer && dst.IsNil() {
 			// If dst is nil create a new instance of the underlying type and set dst to the pointer of that instance.
 			dst.Set(reflect.New(dst.Type().Elem()))
 		}
@@ -176,7 +176,7 @@ func structToStruct(filter FieldFilter, src, dst *reflect.Value, userOptions *op
 		}
 
 		srcElem, dstElem := src.Elem(), *dst
-		if dst.Kind() == reflect.Ptr {
+		if dst.Kind() == reflect.Pointer {
 			dstElem = dst.Elem()
 		}
 
@@ -191,7 +191,7 @@ func structToStruct(filter FieldFilter, src, dst *reflect.Value, userOptions *op
 			break
 		}
 		if dst.IsNil() {
-			if src.Elem().Kind() != reflect.Ptr {
+			if src.Elem().Kind() != reflect.Pointer {
 				// Non-pointer interface implementations are not addressable.
 				return errors.Errorf("expected a pointer for an interface value, got %s instead", src.Elem().Kind())
 			}
@@ -213,7 +213,7 @@ func structToStruct(filter FieldFilter, src, dst *reflect.Value, userOptions *op
 		dstLen := dst.Len()
 		srcLen := userOptions.CopyListSize(src)
 
-		for i := 0; i < srcLen; i++ {
+		for i := range srcLen {
 			srcItem := src.Index(i)
 			var dstItem reflect.Value
 			if i < dstLen {
@@ -243,7 +243,7 @@ func structToStruct(filter FieldFilter, src, dst *reflect.Value, userOptions *op
 		if dstLen < srcLen {
 			return errors.Errorf("dst array size %d is less than src size %d", dstLen, srcLen)
 		}
-		for i := 0; i < srcLen; i++ {
+		for i := range srcLen {
 			srcItem := src.Index(i)
 			dstItem := dst.Index(i)
 			if err := structToStruct(filter, &srcItem, &dstItem, userOptions); err != nil {
@@ -255,7 +255,7 @@ func structToStruct(filter FieldFilter, src, dst *reflect.Value, userOptions *op
 		if !dst.CanSet() {
 			return errors.Errorf("dst %s, %s is not settable", dst, dst.Type())
 		}
-		if dst.Kind() == reflect.Ptr {
+		if dst.Kind() == reflect.Pointer {
 			if !src.CanAddr() {
 				return errors.Errorf("src %s, %s is not addressable", src, src.Type())
 			}
@@ -299,7 +299,7 @@ type options struct {
 	// after conversion.
 	// If a converter returns an error that error is propagated to the
 	// initial call of StructToStruct.
-	ConverterHooks []func(src, dst *reflect.Value) (interface{}, error)
+	ConverterHooks []func(src, dst *reflect.Value) (any, error)
 }
 
 // mapVisitor is called for every filtered field in structToMap.
@@ -350,7 +350,7 @@ func WithUnmarshalAllAny(unmarshal bool) Option {
 }
 
 // WithConverterHook adds a converter hook to convert from src to dst.
-func WithConverterHook(converter func(src, dst *reflect.Value) (interface{}, error)) Option {
+func WithConverterHook(converter func(src, dst *reflect.Value) (any, error)) Option {
 	return func(o *options) {
 		o.ConverterHooks = append(o.ConverterHooks, converter)
 	}
@@ -373,17 +373,17 @@ func fieldName(tag string, f reflect.StructField) string {
 	if !ok {
 		return f.Name
 	}
-	firstComma := strings.Index(lookupResult, ",")
-	if firstComma == -1 {
+	before, _, ok := strings.Cut(lookupResult, ",")
+	if !ok {
 		return lookupResult
 	}
-	return lookupResult[:firstComma]
+	return before
 }
 
 // StructToMap copies `src` struct to the `dst` map.
 // Behavior is similar to `StructToStruct`.
 // Arrays in the non-empty dst are converted to slices.
-func StructToMap(filter FieldFilter, src interface{}, dst map[string]interface{}, userOpts ...Option) error {
+func StructToMap(filter FieldFilter, src any, dst map[string]any, userOpts ...Option) error {
 	opts := newDefaultOptions()
 	for _, o := range userOpts {
 		o(opts)
@@ -418,7 +418,7 @@ func structToMap(filter FieldFilter, src, dst reflect.Value, userOptions *option
 				if srcField.IsValid() {
 					mapValue = newValue(srcField.Type())
 				} else {
-					dstMap := dst.Interface().(map[string]interface{})
+					dstMap := dst.Interface().(map[string]any)
 					dstMap[dstName] = nil
 					continue
 				}
@@ -447,7 +447,7 @@ func structToMap(filter FieldFilter, src, dst reflect.Value, userOptions *option
 			dst.SetMapIndex(reflect.ValueOf(dstName), mapValue)
 		}
 
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if src.IsNil() {
 			reflect.ValueOf(dst).Set(reflect.ValueOf(nil))
 			break
@@ -492,7 +492,7 @@ func structToMap(filter FieldFilter, src, dst reflect.Value, userOptions *option
 				dst = sliceDst
 			}
 			var err error
-			for i := 0; i < desiredDstLen; i++ {
+			for i := range desiredDstLen {
 				itemExists := false
 				var subDst reflect.Value
 				if i < dst.Len() {
@@ -523,7 +523,7 @@ func structToMap(filter FieldFilter, src, dst reflect.Value, userOptions *option
 }
 
 func indirect(v reflect.Value) reflect.Value {
-	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
 		v = v.Elem()
 	}
 	return v
@@ -531,7 +531,7 @@ func indirect(v reflect.Value) reflect.Value {
 
 // isPrimitive checks whether the given kind is simple enough so that it can be copied directly without recursion.
 func isPrimitive(kind reflect.Kind) bool {
-	return kind != reflect.Ptr &&
+	return kind != reflect.Pointer &&
 		kind != reflect.Struct &&
 		kind != reflect.Interface &&
 		kind != reflect.Slice &&
@@ -543,12 +543,12 @@ func isPrimitive(kind reflect.Kind) bool {
 func newValue(t reflect.Type) reflect.Value {
 	switch t.Kind() {
 	case reflect.Struct:
-		return reflect.MakeMap(reflect.TypeOf(map[string]interface{}{}))
+		return reflect.MakeMap(reflect.TypeFor[map[string]any]())
 
 	case reflect.Array, reflect.Slice:
 		return reflect.MakeSlice(reflect.SliceOf(newValue(t.Elem()).Type()), 0, 0)
 
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return newValue(t.Elem())
 
 	default:

--- a/copy.go
+++ b/copy.go
@@ -51,29 +51,36 @@ func ensureCompatible(src, dst *reflect.Value) error {
 }
 
 func structToStruct(filter FieldFilter, src, dst *reflect.Value, userOptions *options) error {
-	if err := ensureCompatible(src, dst); err != nil {
-		// incompatible, try using converters:
-		converted := false
-		for _, fn := range userOptions.ConverterHooks {
-			data, err := fn(src, dst)
-			if err != nil {
-				// error during conversion, pass upwards
-				return err
-			}
-			rdata := reflect.ValueOf(data)
-			if err := ensureCompatible(&rdata, dst); err != nil {
-				// no change using conversion, try next
-				continue
-			}
-
-			// it is convertable, replace src
-			src = &rdata
-			converted = true
-			break
-		}
-		if !converted {
+	// Apply user conversions as early as possible to allow replacements of src.
+	// This allows users (providing a converter) to assign protobuf message structs
+	// to golang primitive types.
+	for _, fn := range userOptions.ConverterHooks {
+		data, err := fn(src, dst)
+		if err != nil {
+			// error during conversion; pass upwards
 			return err
 		}
+
+		rdata := reflect.ValueOf(data)
+		if !rdata.IsValid() || rdata.Type() == src.Type() {
+			// invalid or converter didn't change the type; keep original (addressable) src
+			continue
+		}
+
+		if err := ensureCompatible(&rdata, dst); err != nil {
+			// no change using conversion; try next
+			continue
+		}
+
+		// it is convertable; replace src
+		src = &rdata
+
+		// keep going as we want to allow converter chaining
+	}
+
+	// final check to ensure types are compatible
+	if err := ensureCompatible(src, dst); err != nil {
+		return err
 	}
 
 	switch src.Kind() {

--- a/copy_proto_test.go
+++ b/copy_proto_test.go
@@ -343,25 +343,25 @@ func TestStructToStruct_UnknownAnySubfieldMask(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 func TestStructToMap_Success(t *testing.T) {
-	userDst := make(map[string]interface{})
+	userDst := make(map[string]any)
 	mask := fieldmask_utils.MaskFromString(
 		"Id,Avatar{OriginalUrl},Tags,Images,Permissions,Friends{Images{ResizedUrl}}")
 	err := fieldmask_utils.StructToMap(mask, testUserFull, userDst)
 	require.Nil(t, err)
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"Id": testUserFull.Id,
-		"Avatar": map[string]interface{}{
+		"Avatar": map[string]any{
 			"OriginalUrl": testUserFull.Avatar.OriginalUrl,
 		},
 		"Tags": testUserFull.Tags,
-		"Images": []map[string]interface{}{
+		"Images": []map[string]any{
 			{"OriginalUrl": testUserFull.Images[0].OriginalUrl, "ResizedUrl": testUserFull.Images[0].ResizedUrl},
 			{"OriginalUrl": testUserFull.Images[1].OriginalUrl, "ResizedUrl": testUserFull.Images[1].ResizedUrl},
 		},
 		"Permissions": testUserFull.Permissions,
-		"Friends": []map[string]interface{}{
+		"Friends": []map[string]any{
 			{
-				"Images": []map[string]interface{}{
+				"Images": []map[string]any{
 					{"ResizedUrl": testUserFull.Friends[0].Images[0].ResizedUrl},
 					{"ResizedUrl": testUserFull.Friends[0].Images[1].ResizedUrl},
 				},
@@ -372,15 +372,15 @@ func TestStructToMap_Success(t *testing.T) {
 }
 
 func TestStructToMap_PartialProtoSuccess(t *testing.T) {
-	userDst := make(map[string]interface{})
+	userDst := make(map[string]any)
 	mask := fieldmask_utils.MaskFromString(
 		"Id,Avatar{OriginalUrl},Images,Username,Permissions,Name{MaleName}")
 	err := fieldmask_utils.StructToMap(mask, testUserPartial, userDst)
 	require.Nil(t, err)
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"Id":          testUserPartial.Id,
 		"Avatar":      nil,
-		"Images":      []map[string]interface{}{},
+		"Images":      []map[string]any{},
 		"Username":    testUserPartial.Username,
 		"Permissions": []testproto.Permission(nil),
 		"Name":        nil,

--- a/copy_test.go
+++ b/copy_test.go
@@ -925,7 +925,7 @@ type StringerImpl struct {
 	Name string
 }
 
-func (*StringerImpl) someMethod() {}
+func (*StringerImpl) someMethod() {} // nolint:unused
 func (f *StringerImpl) String() string {
 	return f.Name
 }
@@ -1033,7 +1033,7 @@ func TestStructToStruct_DifferentDstKind(t *testing.T) {
 		Field int
 	}
 	src := &A{Field: 1}
-	dst := &map[string]interface{}{}
+	dst := &map[string]any{}
 	mask := fieldmask_utils.MaskFromString("")
 	err := fieldmask_utils.StructToStruct(mask, src, dst)
 	assert.Error(t, err)
@@ -1179,13 +1179,13 @@ func TestStructToMap_NestedStruct_EmptyDst(t *testing.T) {
 			Field2: 1,
 		},
 	}
-	dst := make(map[string]interface{})
+	dst := make(map[string]any)
 	mask := fieldmask_utils.MaskFromString("Field1,A{Field2}")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Field1": src.Field1,
-		"A": map[string]interface{}{
+		"A": map[string]any{
 			"Field2": src.A.Field2,
 		},
 	}, dst)
@@ -1208,13 +1208,13 @@ func TestStructToMap_NestedStruct_EmptyDst_OptionDst(t *testing.T) {
 			Field2: 1,
 		},
 	}
-	dst := make(map[string]interface{})
+	dst := make(map[string]any)
 	mask := fieldmask_utils.MaskFromString("Field1,A{Field2}")
 	err := fieldmask_utils.StructToMap(mask, src, dst, opts)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Field1": src.Field1,
-		"another_name": map[string]interface{}{
+		"another_name": map[string]any{
 			"some_field": src.A.Field2,
 		},
 	}, dst)
@@ -1236,8 +1236,8 @@ func TestStructToMap_NestedStruct_NonEmptyDst(t *testing.T) {
 			Field2: 1,
 		},
 	}
-	dst := map[string]interface{}{
-		"A": map[string]interface{}{
+	dst := map[string]any{
+		"A": map[string]any{
 			"Field1": "existing value",
 			"Field2": 10,
 		},
@@ -1245,9 +1245,9 @@ func TestStructToMap_NestedStruct_NonEmptyDst(t *testing.T) {
 	mask := fieldmask_utils.MaskFromString("Field1,A{Field2}")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Field1": src.Field1,
-		"A": map[string]interface{}{
+		"A": map[string]any{
 			"Field1": "existing value",
 			"Field2": src.A.Field2,
 		},
@@ -1270,13 +1270,13 @@ func TestStructToMap_PtrToStruct_EmptyDst(t *testing.T) {
 			Field2: 1,
 		},
 	}
-	dst := make(map[string]interface{})
+	dst := make(map[string]any)
 	mask := fieldmask_utils.MaskFromString("Field1,A{Field2}")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Field1": src.Field1,
-		"A": map[string]interface{}{
+		"A": map[string]any{
 			"Field2": src.A.Field2,
 		},
 	}, dst)
@@ -1298,8 +1298,8 @@ func TestStructToMap_PtrToStruct_NonEmptyDst(t *testing.T) {
 			Field2: 1,
 		},
 	}
-	dst := map[string]interface{}{
-		"A": map[string]interface{}{
+	dst := map[string]any{
+		"A": map[string]any{
 			"Field1": "existing value",
 			"Field2": 10,
 		},
@@ -1307,9 +1307,9 @@ func TestStructToMap_PtrToStruct_NonEmptyDst(t *testing.T) {
 	mask := fieldmask_utils.MaskFromString("Field1,A{Field2}")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Field1": src.Field1,
-		"A": map[string]interface{}{
+		"A": map[string]any{
 			"Field1": "existing value",
 			"Field2": src.A.Field2,
 		},
@@ -1332,12 +1332,12 @@ func TestStructToMap_ArrayOfStructs_EmptyDst(t *testing.T) {
 			},
 		},
 	}
-	dst := make(map[string]interface{})
+	dst := make(map[string]any)
 	mask := fieldmask_utils.MaskFromString("A{Field2}")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
-		"A": []map[string]interface{}{
+	assert.Equal(t, map[string]any{
+		"A": []map[string]any{
 			{
 				"Field2": src.A[0].Field2,
 			},
@@ -1361,8 +1361,8 @@ func TestStructToMap_SliceOfStructs_NonEmptyDst(t *testing.T) {
 			},
 		},
 	}
-	dst := map[string]interface{}{
-		"A": []map[string]interface{}{
+	dst := map[string]any{
+		"A": []map[string]any{
 			{
 				"Field1": "dst field1",
 			},
@@ -1371,8 +1371,8 @@ func TestStructToMap_SliceOfStructs_NonEmptyDst(t *testing.T) {
 	mask := fieldmask_utils.MaskFromString("A{Field2}")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
-		"A": []map[string]interface{}{
+	assert.Equal(t, map[string]any{
+		"A": []map[string]any{
 			{
 				"Field1": "dst field1",
 				"Field2": src.A[0].Field2,
@@ -1389,13 +1389,13 @@ func TestStructToMap_EntireSlicePrimitive_NonEmptyDst(t *testing.T) {
 		Field1: []int{1, 2, 4, 8},
 	}
 
-	dst := map[string]interface{}{
+	dst := map[string]any{
 		"Field1": []int{16, 32, 64},
 	}
 	mask := fieldmask_utils.MaskFromString("Field1")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Field1": src.Field1,
 	}, dst)
 }
@@ -1420,8 +1420,8 @@ func TestStructToMap_EntireSlice_NonEmptyDst(t *testing.T) {
 			},
 		},
 	}
-	dst := map[string]interface{}{
-		"A": []map[string]interface{}{
+	dst := map[string]any{
+		"A": []map[string]any{
 			{
 				"Field1": "dst ele1 field1",
 			},
@@ -1436,8 +1436,8 @@ func TestStructToMap_EntireSlice_NonEmptyDst(t *testing.T) {
 	mask := fieldmask_utils.MaskFromString("A")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
-		"A": []map[string]interface{}{
+	assert.Equal(t, map[string]any{
+		"A": []map[string]any{
 			{
 				"Field1": src.A[0].Field1,
 				"Field2": src.A[0].Field2,
@@ -1459,8 +1459,8 @@ func TestStructToMap_NilSrcSlice_NonEmptyDst(t *testing.T) {
 		FieldA []A
 	}
 	src := &B{FieldA: nil}
-	dst := map[string]interface{}{
-		"FieldA": []map[string]interface{}{
+	dst := map[string]any{
+		"FieldA": []map[string]any{
 			{
 				"Field1": "dst ele1 field1",
 			},
@@ -1475,8 +1475,8 @@ func TestStructToMap_NilSrcSlice_NonEmptyDst(t *testing.T) {
 	mask := fieldmask_utils.MaskFromString("FieldA")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
-		"FieldA": []map[string]interface{}{},
+	assert.Equal(t, map[string]any{
+		"FieldA": []map[string]any{},
 	}, dst)
 }
 
@@ -1500,8 +1500,8 @@ func TestStructToMap_EntireSlice_DstSliceLenIsLessThanSource(t *testing.T) {
 			},
 		},
 	}
-	dst := map[string]interface{}{
-		"A": []map[string]interface{}{
+	dst := map[string]any{
+		"A": []map[string]any{
 			{
 				"Field1": "dst ele1 field1",
 			},
@@ -1510,8 +1510,8 @@ func TestStructToMap_EntireSlice_DstSliceLenIsLessThanSource(t *testing.T) {
 	mask := fieldmask_utils.MaskFromString("A")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
-		"A": []map[string]interface{}{
+	assert.Equal(t, map[string]any{
+		"A": []map[string]any{
 			{
 				"Field1": "src ele1 field1",
 				"Field2": "src ele1 field2",
@@ -1548,8 +1548,8 @@ func TestStructToMap_Array_NonEmptyDst(t *testing.T) {
 			},
 		},
 	}
-	dst := map[string]interface{}{
-		"A": [2]map[string]interface{}{
+	dst := map[string]any{
+		"A": [2]map[string]any{
 			{
 				"Field1": "dst ele1 field1",
 			},
@@ -1561,8 +1561,8 @@ func TestStructToMap_Array_NonEmptyDst(t *testing.T) {
 	mask := fieldmask_utils.MaskFromString("A{Field2}")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
-		"A": []map[string]interface{}{
+	assert.Equal(t, map[string]any{
+		"A": []map[string]any{
 			{
 				"Field1": "dst ele1 field1",
 				"Field2": "src ele1 field2",
@@ -1586,13 +1586,13 @@ func TestStructToMap_ArrayPrimitive_NonEmptyDst(t *testing.T) {
 		Field1: [5]int{1, 2, 4, 8, 10},
 	}
 
-	dst := map[string]interface{}{
+	dst := map[string]any{
 		"Field1": [4]int{16, 32, 64, 0},
 	}
 	mask := fieldmask_utils.MaskFromString("Field1")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Field1": [5]int{1, 2, 4, 8, 10},
 	}, dst)
 }
@@ -1605,13 +1605,13 @@ func TestStructToMap_EmptySliceSrc_NonEmptyArrayDst(t *testing.T) {
 		Field1: []int{},
 	}
 
-	dst := map[string]interface{}{
+	dst := map[string]any{
 		"Field1": [4]int{16, 32, 64, 0},
 	}
 	mask := fieldmask_utils.MaskFromString("Field1")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Field1": src.Field1,
 	}, dst)
 }
@@ -1717,7 +1717,7 @@ func TestStructToMap_CopyStructSlice_WithMaxCopyListSize(t *testing.T) {
 	src := &A{
 		Field1: []AA{{1}, {2}, {3}},
 	}
-	dst := map[string]interface{}{}
+	dst := map[string]any{}
 
 	const copySize int = 2
 	mask := fieldmask_utils.MaskFromString("Field1")
@@ -1725,8 +1725,8 @@ func TestStructToMap_CopyStructSlice_WithMaxCopyListSize(t *testing.T) {
 		return copySize
 	}))
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
-		"Field1": []map[string]interface{}{{"Field": 1}, {"Field": 2}},
+	assert.Equal(t, map[string]any{
+		"Field1": []map[string]any{{"Field": 1}, {"Field": 2}},
 	}, dst)
 }
 
@@ -1738,7 +1738,7 @@ func TestStructToMap_CopyIntSlice_WithMaxCopyListSize(t *testing.T) {
 	src := &A{
 		Field1: []int{1, 2, 3},
 	}
-	dst := map[string]interface{}{}
+	dst := map[string]any{}
 
 	const copySize int = 2
 	mask := fieldmask_utils.MaskFromString("Field1")
@@ -1746,7 +1746,7 @@ func TestStructToMap_CopyIntSlice_WithMaxCopyListSize(t *testing.T) {
 		return copySize
 	}))
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Field1": []int{1, 2},
 	}, dst)
 }
@@ -1763,7 +1763,7 @@ func TestStructToMap_CopyStructArray_WithMaxCopyListSize(t *testing.T) {
 	src := &A{
 		Field1: [3]AA{{1}, {2}, {3}},
 	}
-	dst := map[string]interface{}{}
+	dst := map[string]any{}
 
 	const copySize int = arraySize - 1
 	mask := fieldmask_utils.MaskFromString("Field1")
@@ -1771,8 +1771,8 @@ func TestStructToMap_CopyStructArray_WithMaxCopyListSize(t *testing.T) {
 		return copySize
 	}))
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
-		"Field1": []map[string]interface{}{{"Field": 1}, {"Field": 2}},
+	assert.Equal(t, map[string]any{
+		"Field1": []map[string]any{{"Field": 1}, {"Field": 2}},
 	}, dst)
 }
 
@@ -1785,13 +1785,13 @@ func TestStructToMap_CopyIntArray_WithMaxCopyListSize(t *testing.T) {
 		Field1: [arraySize]int{1, 2, 3},
 	}
 	const copySize int = arraySize - 1
-	dst := map[string]interface{}{}
+	dst := map[string]any{}
 	mask := fieldmask_utils.MaskFromString("Field1")
 	err := fieldmask_utils.StructToMap(mask, src, dst, fieldmask_utils.WithCopyListSize(func(src *reflect.Value) int {
 		return copySize
 	}))
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Field1": src.Field1[:copySize],
 	}, dst)
 }
@@ -1803,7 +1803,7 @@ func TestStructToMap_CopyStructWithPrivateFields_WithMapVisitor(t *testing.T) {
 	}
 	unixTime := time.Unix(10, 10)
 	src := &A{Time: unixTime}
-	dst := map[string]interface{}{}
+	dst := map[string]any{}
 	mask := fieldmask_utils.MaskFromString("Time")
 	err := fieldmask_utils.StructToMap(mask, src, dst, fieldmask_utils.WithMapVisitor(
 		func(_ fieldmask_utils.FieldFilter, _, dst reflect.Value,
@@ -1817,7 +1817,7 @@ func TestStructToMap_CopyStructWithPrivateFields_WithMapVisitor(t *testing.T) {
 			return fieldmask_utils.MapVisitorResult{}
 		}))
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Time": unixTime,
 	}, dst)
 }
@@ -1829,7 +1829,7 @@ func TestStructToMap_MapVisitorVisitsOnlyFilteredFields(t *testing.T) {
 		Field3 int
 	}
 	src := &A{Field1: 42, Field2: "hello", Field3: 44}
-	dst := map[string]interface{}{}
+	dst := map[string]any{}
 	mask := fieldmask_utils.MaskFromString("Field1, Field2")
 	var visitedFields []string
 	err := fieldmask_utils.StructToMap(mask, src, dst, fieldmask_utils.WithMapVisitor(
@@ -1849,7 +1849,7 @@ func TestStructToMap_WithMapVisitor_SkipsToNextField(t *testing.T) {
 		Field3 int
 	}
 	src := &A{Field1: 42, Field2: "hello", Field3: 44}
-	dst := map[string]interface{}{}
+	dst := map[string]any{}
 	mask := fieldmask_utils.MaskFromString("Field1, Field2")
 	err := fieldmask_utils.StructToMap(mask, src, dst, fieldmask_utils.WithMapVisitor(
 		func(_ fieldmask_utils.FieldFilter, _, _ reflect.Value,
@@ -1864,7 +1864,7 @@ func TestStructToMap_WithMapVisitor_SkipsToNextField(t *testing.T) {
 			return fieldmask_utils.MapVisitorResult{}
 		}))
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{"Field1": 33, "Field2": "hello"}, dst)
+	assert.Equal(t, map[string]any{"Field1": 33, "Field2": "hello"}, dst)
 }
 
 func TestStructToStruct_CopySlice_WithDiffentItemKind(t *testing.T) {
@@ -1902,7 +1902,7 @@ func TestStructToMap_CopySlice_WithDiffentItemKind(t *testing.T) {
 		Field1: []int{1, 2, 3},
 		Field2: []string{"1", "2", "3"},
 	}
-	dst := map[string]interface{}{}
+	dst := map[string]any{}
 	const copySize int = 1
 	mask := fieldmask_utils.MaskFromString("Field1,Field2")
 	err := fieldmask_utils.StructToMap(mask, src, dst, fieldmask_utils.WithCopyListSize(func(src *reflect.Value) int {
@@ -1913,7 +1913,7 @@ func TestStructToMap_CopySlice_WithDiffentItemKind(t *testing.T) {
 		}
 	}))
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Field1": []int{1},
 		"Field2": []string{"1", "2", "3"},
 	}, dst)
@@ -1960,7 +1960,7 @@ func TestStructToMap_CopySlice_WithDiffentItemType(t *testing.T) {
 		Field1: []int{1, 2, 3},
 		Field2: []AA{{1}, {2}, {3}},
 	}
-	dst := map[string]interface{}{}
+	dst := map[string]any{}
 	const copySize int = 1
 	mask := fieldmask_utils.MaskFromString("Field1,Field2")
 	err := fieldmask_utils.StructToMap(mask, src, dst, fieldmask_utils.WithCopyListSize(func(src *reflect.Value) int {
@@ -1971,9 +1971,9 @@ func TestStructToMap_CopySlice_WithDiffentItemType(t *testing.T) {
 		}
 	}))
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Field1": []int{1, 2, 3},
-		"Field2": []map[string]interface{}{{"Int": 1}},
+		"Field2": []map[string]any{{"Int": 1}},
 	}, dst)
 }
 
@@ -1991,11 +1991,11 @@ func TestStructToStruct_WithMultiTagComma(t *testing.T) {
 		Field int `json:"field,omitempty"`
 	}
 	var src = A{Field: 1}
-	var dst = map[string]interface{}{}
+	var dst = map[string]any{}
 	mask := fieldmask_utils.MaskFromString("Field")
 	err := fieldmask_utils.StructToMap(mask, src, dst, fieldmask_utils.WithTag("json"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"field": 1,
 	}, dst)
 }
@@ -2003,28 +2003,28 @@ func TestStructToStruct_WithMultiTagComma(t *testing.T) {
 func TestStructToMap_WithInterface(t *testing.T) {
 	type user struct {
 		A string
-		B interface{}
-		C interface{}
+		B any
+		C any
 	}
 	type c struct {
 		A int
-		B interface{}
+		B any
 	}
 	mask := fieldmask_utils.MaskFromString("A,B,C")
 
 	src := &user{
 		A: "nick",
 		B: []int{1, 2, 3, 4},
-		C: c{A: 42, B: map[string]interface{}{"hi": 34}},
+		C: c{A: 42, B: map[string]any{"hi": 34}},
 	}
-	dst := make(map[string]interface{})
+	dst := make(map[string]any)
 	err := fieldmask_utils.StructToMap(mask, src, dst, fieldmask_utils.WithTag(`json`))
 	assert.Nil(t, err)
 
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"A": "nick",
 		"B": []int{1, 2, 3, 4},
-		"C": map[string]interface{}{"A": 42, "B": map[string]interface{}{"hi": 34}},
+		"C": map[string]any{"A": 42, "B": map[string]any{"hi": 34}},
 	}
 	assert.Equal(t, expected, dst)
 }
@@ -2041,11 +2041,11 @@ func TestStructToMap_PtrToInt(t *testing.T) {
 		MyInt:    &myInt,
 		WhatEver: "hello",
 	}
-	dst := make(map[string]interface{})
+	dst := make(map[string]any)
 	err := fieldmask_utils.StructToMap(mask, src, dst)
 	assert.Nil(t, err)
 
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"MyInt":    int64(42),
 		"WhatEver": "hello",
 	}
@@ -2062,7 +2062,7 @@ func TestStructToMap_DifferentTypeWithSameDstKey(t *testing.T) {
 		FieldB []BB `json:"FieldA"`
 	}
 	var src1 = A1{FieldA: []int{1, 2}, FieldB: []BB{{1}, {2}}}
-	var dst1 = map[string]interface{}{}
+	var dst1 = map[string]any{}
 	mask := fieldmask_utils.MaskFromString("FieldA,FieldB")
 	err := fieldmask_utils.StructToMap(mask, src1, dst1, fieldmask_utils.WithTag("json"))
 	require.Error(t, err)
@@ -2072,7 +2072,7 @@ func TestStructToMap_DifferentTypeWithSameDstKey(t *testing.T) {
 		FieldB [2]BB `json:"FieldA"`
 	}
 	var src2 = A2{FieldA: [2]int{1, 2}, FieldB: [2]BB{{1}, {2}}}
-	var dst2 = map[string]interface{}{}
+	var dst2 = map[string]any{}
 	mask = fieldmask_utils.MaskFromString("FieldA,FieldB")
 	err = fieldmask_utils.StructToMap(mask, src2, dst2, fieldmask_utils.WithTag("json"))
 	require.Error(t, err)
@@ -2085,7 +2085,7 @@ func TestStructToMap_EmptySrcSlice_JsonEncode(t *testing.T) {
 	}
 
 	src := &B{[]*A{}}
-	dst := make(map[string]interface{})
+	dst := make(map[string]any)
 
 	mask := fieldmask_utils.MaskFromString("As")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
@@ -2103,7 +2103,7 @@ func TestStructToMap_NilSrcSlice_JsonEncode(t *testing.T) {
 	}
 
 	src := &B{}
-	dst := make(map[string]interface{})
+	dst := make(map[string]any)
 
 	mask := fieldmask_utils.MaskFromString("As")
 	err := fieldmask_utils.StructToMap(mask, src, dst)
@@ -2251,20 +2251,20 @@ func TestStructToMap_WithSrcTag(t *testing.T) {
 		},
 	}
 	mask := fieldmask_utils.MaskFromString("Field1,A{Field2}")
-	dst := make(map[string]interface{})
+	dst := make(map[string]any)
 	err := fieldmask_utils.StructToMap(mask, src, dst, fieldmask_utils.WithTag("json"), fieldmask_utils.WithSrcTag("db"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Field1": src.Field1,
 	}, dst)
 
 	mask, _ = fieldmask_utils.MaskFromPaths([]string{"Field1", "another_name.some_field1", "another_name.some_field2"}, func(s string) string { return s })
-	dst = make(map[string]interface{})
+	dst = make(map[string]any)
 	err = fieldmask_utils.StructToMap(mask, src, dst, fieldmask_utils.WithTag("json"), fieldmask_utils.WithSrcTag("db"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"Field1": src.Field1,
-		"another_name_json": map[string]interface{}{
+		"another_name_json": map[string]any{
 			"some_field1_json": src.A.Field2,
 			"some_field2_json": false,
 		},
@@ -2314,7 +2314,7 @@ func TestStructToStruct_WithConverterHook(t *testing.T) {
 
 	// test conversion errors are critical
 	err = fieldmask_utils.StructToStruct(mask, src, dst,
-		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (interface{}, error) {
+		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (any, error) {
 			return nil, errors.New("dummy error")
 		}))
 	require.Error(t, err)
@@ -2322,7 +2322,7 @@ func TestStructToStruct_WithConverterHook(t *testing.T) {
 
 	// test incompatible conversion still returns original error
 	err = fieldmask_utils.StructToStruct(mask, src, dst,
-		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (interface{}, error) {
+		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (any, error) {
 			return 3.14, nil
 		}))
 	require.Error(t, err)
@@ -2331,7 +2331,7 @@ func TestStructToStruct_WithConverterHook(t *testing.T) {
 	// test successful conversion
 	err = fieldmask_utils.StructToStruct(mask, src, dst,
 		// convert string to int64
-		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (interface{}, error) {
+		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (any, error) {
 			data := src.Interface()
 
 			if src.Kind() != reflect.String ||
@@ -2347,7 +2347,7 @@ func TestStructToStruct_WithConverterHook(t *testing.T) {
 			return strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
 		}),
 		// convert string to float64
-		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (interface{}, error) {
+		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (any, error) {
 			data := src.Interface()
 
 			if src.Kind() != reflect.String ||
@@ -2363,7 +2363,7 @@ func TestStructToStruct_WithConverterHook(t *testing.T) {
 			return strconv.ParseFloat(strings.TrimSpace(raw), 64)
 		}),
 		// convert *timestamppb.Timestamp to time.Time
-		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (interface{}, error) {
+		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (any, error) {
 			data := src.Interface()
 
 			if src.Kind() != reflect.TypeFor[*timestamppb.Timestamp]().Kind() ||

--- a/copy_test.go
+++ b/copy_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	fieldmask_utils "github.com/mennanov/fieldmask-utils"
 )
@@ -2283,6 +2284,7 @@ func TestStructToStruct_WithConverterHook(t *testing.T) {
 		Field2 []*E
 		Field3 []*E
 		Field4 []string
+		Field5 *timestamppb.Timestamp
 	}
 	src := &A{
 		Field1: "   42   ",
@@ -2291,15 +2293,20 @@ func TestStructToStruct_WithConverterHook(t *testing.T) {
 			{Field1: "foo"},
 		},
 		Field4: []string{"   3.141   ", "-273.15"},
+		Field5: &timestamppb.Timestamp{
+			Seconds: 1780396738,
+			Nanos:   42,
+		},
 	}
 	type B struct {
 		Field1 int64
 		Field2 []*F
 		Field3 []*F
 		Field4 []float64
+		Field5 time.Time
 	}
 	dst := &B{}
-	mask := fieldmask_utils.MaskFromString("Field1,Field2,Field3,Field4")
+	mask := fieldmask_utils.MaskFromString("Field1,Field2,Field3,Field4,Field5")
 
 	// test original error due to no conversion
 	err := fieldmask_utils.StructToStruct(mask, src, dst)
@@ -2354,6 +2361,22 @@ func TestStructToStruct_WithConverterHook(t *testing.T) {
 			}
 
 			return strconv.ParseFloat(strings.TrimSpace(raw), 64)
+		}),
+		// convert *timestamppb.Timestamp to time.Time
+		fieldmask_utils.WithConverterHook(func(src, dst *reflect.Value) (interface{}, error) {
+			data := src.Interface()
+
+			if src.Kind() != reflect.TypeFor[*timestamppb.Timestamp]().Kind() ||
+				dst.Kind() != reflect.TypeFor[time.Time]().Kind() {
+				return data, nil
+			}
+
+			raw, ok := data.(*timestamppb.Timestamp)
+			if !ok {
+				return data, nil
+			}
+
+			return raw.AsTime(), nil
 		}))
 	require.NoError(t, err)
 	assert.Equal(t, &B{
@@ -2363,5 +2386,25 @@ func TestStructToStruct_WithConverterHook(t *testing.T) {
 			{Field1: "foo"},
 		},
 		Field4: []float64{3.141, -273.15},
+		Field5: time.Unix(1780396738, 42).UTC(),
 	}, dst)
+}
+
+func TestStructToStruct_ValueToPtr_WithUnrelatedHook(t *testing.T) {
+	type A struct{ Field int }
+	type B struct{ Field *int }
+
+	src := &A{Field: 42}
+	dst := &B{}
+	mask := fieldmask_utils.MaskFromString("Field")
+
+	// A no-op hook that does not apply to this field.
+	hook := fieldmask_utils.WithConverterHook(func(s, d *reflect.Value) (any, error) {
+		return s.Interface(), nil
+	})
+
+	err := fieldmask_utils.StructToStruct(mask, src, dst, hook)
+	require.NoError(t, err)
+	require.NotNil(t, dst.Field)
+	require.Equal(t, 42, *dst.Field)
 }


### PR DESCRIPTION
This fixes issues when trying to assign protobuf messages to primitive types such as: `*timestamppb.Timestamp` to `time.Time`. Previously this would recurse into the generated Timestamp struct and fail to find a dst for the nested Fields `.Seconds` and `.Nanos` (afterall time.Time is not a struct).

By using conversions in the beginning, one can take control of this by detecting the dst type and converting it before recursion would handle it.

This does not break existing behavior.

A second commit modernizes the code. This was done using:
```shell
go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest -fix ./...
go fix ./...
```

Let me know what you think.